### PR TITLE
Avoid temporary vector<Block> to set initial BigUint size

### DIFF
--- a/src/little-big-int.cpp
+++ b/src/little-big-int.cpp
@@ -500,7 +500,7 @@ BigUint operator<<(const BigUint& lhs, const BigUint::Block rhs)
     const std::size_t shiftBlocks(rhs / BigUint::bitsPerBlock);
     const std::size_t shiftBits(rhs % BigUint::bitsPerBlock);
 
-    BigUint result(std::vector<BigUint::Block>(startBlocks + shiftBlocks, 0));
+    BigUint result(BigUint::InitialSize(startBlocks + shiftBlocks));
 
     const auto& start(lhs.data());
     auto& val(result.data());

--- a/src/little-big-int.hpp
+++ b/src/little-big-int.hpp
@@ -262,9 +262,10 @@ public:
     static BigUint sqrt(const BigUint& in);
 
 private:
-    BigUint(std::vector<Block> blocks)
+    enum InitialSize : size_t {};
+    explicit BigUint(InitialSize size)
         : m_arena()
-        , m_val(blocks.begin(), blocks.end(), Alloc(m_arena))
+        , m_val(size, 0, Alloc(m_arena))
     {
         if (m_val.empty()) m_val.push_back(0);
     }

--- a/src/little-big-int.hpp
+++ b/src/little-big-int.hpp
@@ -148,6 +148,8 @@ private:
 template <class T, std::size_t N, std::size_t A = detail::maxAlign>
 class ShortAlloc
 {
+    template <class, std::size_t, std::size_t>
+    friend class ShortAlloc;
 public:
     using value_type = T;
     using ArenaType = Arena<N, A>;
@@ -210,7 +212,7 @@ public:
 
     BigUint& operator=(const BigUint& other)
     {
-        m_val.assign(other.m_val.begin(), other.m_val.end());
+        if (this != &other) m_val.assign(other.m_val.begin(), other.m_val.end());
         return *this;
     }
 


### PR DESCRIPTION
Also added a fix for Visual C++ 2015